### PR TITLE
tests verifies formats

### DIFF
--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -39,13 +39,6 @@ displayEpisode (Episode shnm snm snr enm enr)
 
 type Parser = Parsec Void Text
 
-mySequence :: Parser (String, String)
-mySequence = do
-    a <- many $ satisfy isAlphaNum
-    chunk " - "
-    c <- many $ satisfy isAlphaNum
-    return(a,c)
-
 -- Parse "showName - epnr"
 parseFileFormat_1 :: Parser Episode
 parseFileFormat_1 = do

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -64,8 +64,6 @@ instance Arbitrary Episode where
         epnr <- choose (0,999)
         return $ Episode (Just shnm) (Just snm) (Just snr) (Just epnm) (Just epnr)
 
-type Path = T.Text
-
 instance Arbitrary EpisodeTest where
     arbitrary = do
         e <- arbitrary :: Gen Episode
@@ -75,16 +73,6 @@ instance Arbitrary EpisodeTest where
         file <- formatGen fileFormat e
         let fEpisode = formatEpisode e dirFormat fileFormat
         return $ EpisodeTest fEpisode dirFormat fileFormat $ T.concat [dir,"/",file]
-
-compareEpisode :: Episode -> Episode -> Bool
-compareEpisode (Episode rshn rsen rsnr repn renr) (Episode shn sen snr epn enr) =
-        all compare paired where
-        refrence = [rshn, rsen, T.pack.show <$> rsnr, repn, T.pack.show <$> renr]
-        result   = [shn, sen, T.pack.show <$> snr, epn, T.pack.show <$> enr]
-        paired  = zip refrence result
-        compare (_,Nothing) = True
-        compare (Just a,Just b) = a == b
-        compare _ = error "Empty refrence field in compareEpisode"
 
 generateTag :: Gen T.Text
 generateTag = do


### PR DESCRIPTION
This pr fixes an oversight in the testing, where the test can pass even if the parser returns less results than it should, as long as all of the result match with the source.

To solve this, the source is modified according the results available. Then the source in compared with the result. If there is not a 100% equality, the test fails.  